### PR TITLE
App Base Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    App: require('./lib/App')
+};

--- a/lib/App.js
+++ b/lib/App.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var helpers = require('./helpers'),
+    App;
+
+/**
+ * App is the base class for a standard Ghost App.  Includes empty handlers for life cycle events.
+ * @class
+ * @parameter {Ghost} The current Ghost app instance
+ */
+App = function (ghost) {
+    this.app = ghost;
+
+    this.initialize();
+};
+
+/**
+ * A method that is run after the constructor and allows for special logic
+ */
+App.prototype.initialize = function () {
+    return;
+};
+
+/** 
+ * A method that will be called on installation.
+ * Can optionally return a promise if async.
+ * @parameter {Ghost} The current Ghost app instance
+ */
+App.prototype.install = function () {
+    return;
+};
+
+/** 
+ * A method that will be called on uninstallation.
+ * Can optionally return a promise if async.
+ * @parameter {Ghost} The current Ghost app instance
+ */
+App.prototype.uninstall = function () {
+    return;
+};
+
+/** 
+ * A method that will be called when the App is enabled.
+ * Can optionally return a promise if async.
+ * @parameter {Ghost} The current Ghost app instance
+ */
+App.prototype.activate = function () {
+    return;
+};
+
+/** 
+ * A method that will be called when the App is disabled.
+ * Can optionally return a promise if async.
+ * @parameter {Ghost} The current Ghost app instance
+ */
+App.prototype.deactivate = function () {
+    return;
+};
+
+// Offer an easy to use extend method.
+App.extend = helpers.extend;
+
+module.exports = App;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var _ = require('underscore');
+
+// Taken from Backbone 1.0.0 (http://backbonejs.org)
+// Helper function to correctly set up the prototype chain, for subclasses.
+// Similar to `goog.inherits`, but uses a hash of prototype properties and
+// class properties to be extended.
+var extend = function(protoProps, staticProps) {
+    var parent = this;
+    var child;
+
+    // The constructor function for the new subclass is either defined by you
+    // (the "constructor" property in your `extend` definition), or defaulted
+    // by us to simply call the parent's constructor.
+    if (protoProps && _.has(protoProps, 'constructor')) {
+        child = protoProps.constructor;
+    } else {
+        child = function(){ return parent.apply(this, arguments); };
+    }
+
+    // Add static properties to the constructor function, if supplied.
+    _.extend(child, parent, staticProps);
+
+    // Set the prototype chain to inherit from `parent`, without calling
+    // `parent`'s constructor function.
+    var Surrogate = function() { this.constructor = child; };
+    Surrogate.prototype = parent.prototype;
+    child.prototype = new Surrogate();
+
+    // Add prototype properties (instance properties) to the subclass,
+    // if supplied.
+    if (protoProps) {
+        _.extend(child.prototype, protoProps);
+    }
+
+    // Set a convenience property in case the parent's prototype is needed
+    // later.
+    /*jshint camelcase:false */
+    child.__super__ = parent.prototype;
+    /*jshint camelcase:true */
+    
+    return child;
+};
+
+module.exports = {
+    extend: extend
+};

--- a/test/App_spec.js
+++ b/test/App_spec.js
@@ -1,0 +1,22 @@
+/*global describe, it*/
+'use strict';
+
+var _ = require('underscore'),
+    App = require('../lib/App');
+
+describe('App', function () {
+    it('has correct methods', function () {
+        var app = new App({}),
+            methods = [
+                'initialize',
+                'install',
+                'uninstall',
+                'activate',
+                'deactivate'
+            ];
+        
+        _(methods).each(function (method) {
+            _.isFunction(app[method]).should.equal(true);
+        });
+    });
+});

--- a/test/Module_spec.js
+++ b/test/Module_spec.js
@@ -1,0 +1,11 @@
+/*global describe, it*/
+'use strict';
+
+var _ = require('underscore'),
+    GhostApp = require('../');
+
+describe('Module', function () {
+    it('exports App', function () {
+        _.isObject(GhostApp.App).should.equal(true);
+    });
+});


### PR DESCRIPTION
- Added lib/App with basic lifecycle events and extend method
- Added index.js that exports App
- Added tests for App and Module API

I didn't add the package.json because I figured you wanted to set that up yourself.  To get the tests running I did this:
- `npm install should sinon underscore`
- If you don't have mocha: `npm install -g mocha`
- `mocha -r should test/*_spec.js -R spec`
