### PR TITLE
add ghost permissions to package.json

### DIFF
--- a/examples/no-jquery/package.json
+++ b/examples/no-jquery/package.json
@@ -25,5 +25,10 @@
         "lodash": "~2.4.1"
     },
     "devDependencies": {
+    },
+    "ghost": {
+        "permissions": {
+            "filters": ["ghost_foot"]
+        }
     }
 }


### PR DESCRIPTION
I was testing this out with the latest Ghost code and I found that permissions were necessary to activate it.
From what I can tell, the exact format of these permissions hasn't actually been fleshed out, but at least this keeps the example working in the meantime.
