### PR TITLE
Changes the package.json engine definitions to match Ghost's

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "engines": {
         "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
     },
-    "engineStrict": true,
     "dependencies": {
         "lodash": "2.4.1",
         "when": "~2.5.1"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
         "test": "grunt validate"
     },
     "engines": {
-        "node": "~0.10.0 || ~0.12.0",
-        "iojs": "~1.2.0"
+        "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
     },
     "engineStrict": true,
     "dependencies": {


### PR DESCRIPTION
As the Node LTS 4.2+ is supported we should not limit its usage. Also, engineStrict isn't used in the Ghost and with io.js gone there is no need for one.